### PR TITLE
fix: lib64 builds fail once on clean install

### DIFF
--- a/wscript
+++ b/wscript
@@ -26,13 +26,8 @@ def build(bld):
     # Declare the include directory for the external library
     include_dir = install_dir.make_node("include")
 
-    lib_dir = None
-
-    if install_dir.find_node("lib64"):
-        lib_dir = install_dir.make_node("lib64")
-    else:
-        # Declare the lib directory for the external library
-        lib_dir = install_dir.make_node("lib")
+    lib_dir = install_dir.make_node("lib")
+    lib64_dir = install_dir.make_node("lib64")
 
     # build the external library through an external process
     bld(
@@ -50,7 +45,7 @@ def build(bld):
     else:
         lib_name = "srt"
 
-    bld.read_stlib(lib_name, paths=[lib_dir], export_includes=[include_dir])
+    bld.read_stlib(lib_name, paths=[lib_dir, lib64_dir], export_includes=[include_dir])
 
     if bld.is_toplevel():
         bld.program(


### PR DESCRIPTION
Due to `find_node` creating a task, its not guaranteed to run after the completion of CMakeBuildTask. Since we depended on the output of CMakeBuildTask to switch to lib64, the first build would tend to return false and incorrectly give `lib` on `lib64` based systems.

The fix is to read both paths in read_stlib, instead of using an if statement to choose the correct lib folder.

Fixes: steinwurf/srt#3